### PR TITLE
Yocto build fix 5.15 2.1.x imx

### DIFF
--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -268,6 +268,7 @@ config SOC_IMX7ULP
 	select PINCTRL_IMX7ULP
 	select SOC_IMX7D_CA7 if ARCH_MULTI_V7
 	select SOC_IMX7D_CM4 if ARM_SINGLE_ARMV7M
+	imply GPIO_VF610
 	help
 	  This enables support for Freescale i.MX7 Ultra Low Power processor.
 
@@ -275,6 +276,7 @@ config SOC_VF610
 	bool "Vybrid Family VF610 support"
 	select ARM_GIC if ARCH_MULTI_V7
 	select PINCTRL_VF610
+	imply GPIO_VF610
 
 	help
 	  This enables support for Freescale Vybrid VF610 processor.

--- a/arch/arm/mach-imx/busfreq-imx.c
+++ b/arch/arm/mach-imx/busfreq-imx.c
@@ -180,6 +180,8 @@ static int busfreq_notify(enum busfreq_event event)
 	return notifier_to_errno(ret);
 }
 
+#if defined(CONFIG_HAVE_IMX_BUSFREQ)
+
 int register_busfreq_notifier(struct notifier_block *nb)
 {
 	return raw_notifier_chain_register(&busfreq_notifier_chain, nb);
@@ -191,6 +193,8 @@ int unregister_busfreq_notifier(struct notifier_block *nb)
 	return raw_notifier_chain_unregister(&busfreq_notifier_chain, nb);
 }
 EXPORT_SYMBOL(unregister_busfreq_notifier);
+
+#endif /* CONFIG_HAVE_IMX_BUSFREQ */
 
 static struct clk *origin_step_parent;
 
@@ -818,6 +822,7 @@ static int set_high_bus_freq(int high_bus_freq)
 	return 0;
 }
 
+#if defined(CONFIG_HAVE_IMX_BUSFREQ)
 void request_bus_freq(enum bus_freq_mode mode)
 {
 	mutex_lock(&bus_freq_mutex);
@@ -948,6 +953,8 @@ int get_bus_freq_mode(void)
 	return cur_bus_freq_mode;
 }
 EXPORT_SYMBOL(get_bus_freq_mode);
+
+#endif /* CONFIG_HAVE_IMX_BUSFREQ */
 
 static struct map_desc ddr_iram_io_desc __initdata = {
 	/* .virtual and .pfn are run-time assigned */

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -676,11 +676,11 @@ config GPIO_UNIPHIER
 	  Say yes here to support UniPhier GPIOs.
 
 config GPIO_VF610
-	def_bool y
+	bool "Vybrid VF610/i.MX7ULP GPIO driver"
 	depends on ARCH_MXC
 	select GPIOLIB_IRQCHIP
 	help
-	  Say yes here to support Vybrid vf610 GPIOs.
+	  Say yes here to support Vybrid VF610/i.MX7ULP GPIOs.
 
 config GPIO_VISCONTI
 	tristate "Toshiba Visconti GPIO support"

--- a/drivers/gpu/drm/bridge/it6161.c
+++ b/drivers/gpu/drm/bridge/it6161.c
@@ -8,6 +8,7 @@
 #include <drm/drm_print.h>
 #include <drm/drm_probe_helper.h>
 #include <linux/err.h>
+#include <linux/gpio/consumer.h>
 #include <linux/i2c.h>
 #include <linux/interrupt.h>
 #include <sound/hdmi-codec.h>

--- a/drivers/net/ethernet/freescale/fec_uio.c
+++ b/drivers/net/ethernet/freescale/fec_uio.c
@@ -16,6 +16,7 @@
 #include <linux/busfreq-imx.h>
 #include <linux/of_mdio.h>
 #include "fec.h"
+#include <linux/pinctrl/consumer.h>
 
 struct fec_dev *fec_dev;
 static const char fec_uio_version[] = "FEC UIO driver v1.0";

--- a/scripts/extract-cert.c
+++ b/scripts/extract-cert.c
@@ -23,6 +23,13 @@
 #include <openssl/err.h>
 #include <openssl/engine.h>
 
+/*
+ * OpenSSL 3.0 deprecates the OpenSSL's ENGINE API.
+ *
+ * Remove this if/when that API is no longer used
+ */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #define PKEY_ID_PKCS7 2
 
 static __attribute__((noreturn))

--- a/scripts/sign-file.c
+++ b/scripts/sign-file.c
@@ -30,6 +30,13 @@
 #include <openssl/engine.h>
 
 /*
+ * OpenSSL 3.0 deprecates the OpenSSL's ENGINE API.
+ *
+ * Remove this if/when that API is no longer used
+ */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+/*
  * Use CMS if we have openssl-1.0.0 or newer available - otherwise we have to
  * assume that it's not available and its header file is missing and that we
  * should use PKCS#7 instead.  Switching to the older PKCS#7 format restricts


### PR DESCRIPTION
A patchset we've been maintaining on https://github.com/Freescale/linux-fslc since 5.10 to enable yocto build when using some different defconfig