### PR TITLE
ARM: imx: mach-imx6ul: fix enet init support

### DIFF
--- a/arch/arm/mach-imx/mach-imx6ul.c
+++ b/arch/arm/mach-imx/mach-imx6ul.c
@@ -31,7 +31,10 @@ static void __init imx6ul_enet_clk_init(void)
 static inline void imx6ul_enet_init(void)
 {
 	imx6ul_enet_clk_init();
-	imx6_enet_mac_init("fsl,imx6ul-fec", "fsl,imx6ul-ocotp");
+	if (cpu_is_imx6ul())
+		imx6_enet_mac_init("fsl,imx6ul-fec", "fsl,imx6ul-ocotp");
+	else
+		imx6_enet_mac_init("fsl,imx6ul-fec", "fsl,imx6ull-ocotp");
 }
 
 static void __init imx6ul_init_machine(void)


### PR DESCRIPTION
MAC address can be read from the ocotp, but the current code works only for imx6ul: imx6ull and imx6ulz refer to a different compatible string in the device tree.

Signed-off-by: Pierluigi Passaro <pierluigi.p@variscite.com>