### PR TITLE
drm/bridge: sec-dsim: Set orientation from panel

### DIFF
--- a/drivers/gpu/drm/bridge/sec-dsim.c
+++ b/drivers/gpu/drm/bridge/sec-dsim.c
@@ -2056,6 +2056,12 @@ panel:
 		/* TODO */
 		connector->dpms = DRM_MODE_DPMS_OFF;
 
+		ret = drm_connector_set_orientation_from_panel(connector, dsim->panel);
+		if (ret) {
+			dev_err(dev, "Unable to set orientation: %d\n", ret);
+			goto cleanup_connector;
+		}
+
 		ret = drm_connector_attach_encoder(connector, encoder);
 		if (ret)
 			goto cleanup_connector;


### PR DESCRIPTION
Since [5e41b01a7808 ("drm/panel: Add an API to allow drm to set orientation from panel")](https://github.com/nxp-imx/linux-imx/commit/5e41b01a780893507a0508f16b9c4fa7f7a48557) it is possible to use panel `get_orientation` callback rather than calling `drm_connector_set_panel_orientation()` from within a panel driver that leads to:
```[    3.261543] ------------[ cut here ]------------
[    3.261557] WARNING: CPU: 2 PID: 298 at drivers/gpu/drm/drm_mode_object.c:45 drm_mode_object_add+0x88/0x90
[    3.261578] Modules linked in: btmrvl_sdio btmrvl mwifiex_sdio mwifiex cryptodev(O)
[    3.261599] CPU: 2 PID: 298 Comm: weston Tainted: G        W  O      5.15.71-lts-5.15.y #1
[    3.261605] Hardware name: StreamMagic XXX (DT)
[    3.261609] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[    3.261615] pc : drm_mode_object_add+0x88/0x90
[    3.261622] lr : drm_property_create+0xdc/0x1ac
[    3.261627] sp : ffff8000099bb990
[    3.261630] x29: ffff8000099bb990 x28: 0000000000000023 x27: ffff8000099bbd48
[    3.261639] x26: 0000000000000780 x25: 00000000000000a7 x24: ffff80000947a430
[    3.261648] x23: ffff800008fd84b8 x22: 0000000000000004 x21: 00000000b0b0b0b0
[    3.261656] x20: ffff0000057c6a10 x19: ffff0000052a6800 x18: ffffffffffffffff
[    3.261665] x17: 0000000000000000 x16: 0000000000000000 x15: ffff000004beda1c
[    3.261674] x14: 00000000000001e3 x13: 0000000000000001 x12: 0000000000000000
[    3.261682] x11: 0000000000000000 x10: 00000000000009e0 x9 : 0000000000000000
[    3.261691] x8 : ffff0000057c6b80 x7 : 0000000000000000 x6 : 000000000000003f
[    3.261699] x5 : 0000000000000040 x4 : ffff8000099bb9b0 x3 : 0000000000000001
[    3.261708] x2 : 00000000b0b0b0b0 x1 : ffff0000057c6a10 x0 : 0000000000000001
[    3.261717] Call trace:
[    3.261720]  drm_mode_object_add+0x88/0x90
[    3.261727]  drm_property_create+0xdc/0x1ac
[    3.261731]  drm_property_create_enum+0x2c/0x94
[    3.261737]  drm_connector_set_panel_orientation+0x98/0xc0
[    3.261743]  ili9881c_get_modes+0x54/0x14c
[    3.261752]  drm_panel_get_modes+0x24/0x40
[    3.261757]  sec_mipi_dsim_connector_get_modes+0x1c/0x34
[    3.261763]  drm_helper_probe_single_connector_modes+0x1ac/0x790
[    3.261771]  drm_mode_getconnector+0x2ac/0x570
[    3.261778]  drm_ioctl_kernel+0xc4/0x114
[    3.261783]  drm_ioctl+0x214/0x44c
[    3.261788]  __arm64_sys_ioctl+0xa8/0xf0
[    3.261796]  invoke_syscall+0x48/0x114
[    3.261803]  el0_svc_common.constprop.0+0x44/0xfc
[    3.261809]  do_el0_svc+0x28/0x90
[    3.261815]  el0_svc+0x28/0x80
[    3.261821]  el0t_64_sync_handler+0xa4/0x130
[    3.261827]  el0t_64_sync+0x1a0/0x1a4
[    3.261833] ---[ end trace d008dc3dcf118dfe ]---
[    3.261883] ------------[ cut here ]------------
[    3.261888] WARNING: CPU: 2 PID: 298 at drivers/gpu/drm/drm_mode_object.c:242 drm_object_attach_property+0x6c/0xb0
[    3.261899] Modules linked in: btmrvl_sdio btmrvl mwifiex_sdio mwifiex cryptodev(O)
[    3.261914] CPU: 2 PID: 298 Comm: weston Tainted: G        W  O      5.15.71-lts-5.15.y #1
[    3.261920] Hardware name: StreamMagic XXX (DT)
[    3.261923] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[    3.261929] pc : drm_object_attach_property+0x6c/0xb0
[    3.261936] lr : drm_connector_set_panel_orientation+0x5c/0xc0
[    3.261942] sp : ffff8000099bba30
[    3.261944] x29: ffff8000099bba30 x28: 0000000000000023 x27: ffff8000099bbd48
[    3.261953] x26: 0000000000000780 x25: 00000000000000a7 x24: ffff80000947a430
[    3.261962] x23: 0000000000000000 x22: ffff00000540b008 x21: ffff0000052a6800
[    3.261971] x20: ffff0000052a78a0 x19: ffff0000052a78a0 x18: ffffffffffffffff
[    3.261980] x17: 0000000000000000 x16: 0000000000000000 x15: ffff000004beda1c
[    3.261988] x14: 00000000000001e3 x13: 0000000000000001 x12: 0000000000000000
[    3.261997] x11: 0000000000000000 x10: 00000000000009e0 x9 : 0000000000000000
[    3.262005] x8 : ffff0000057c6700 x7 : 00000000c0c0c0c0 x6 : 00000000c0c0c0c0
[    3.262014] x5 : 0000000000000000 x4 : 0000000000000001 x3 : 0000000000000006
[    3.262022] x2 : 0000000000000003 x1 : ffff0000057c6a00 x0 : ffff0000052a78c8
[    3.262030] Call trace:
[    3.262033]  drm_object_attach_property+0x6c/0xb0
[    3.262039]  ili9881c_get_modes+0x54/0x14c
[    3.262047]  drm_panel_get_modes+0x24/0x40
[    3.262052]  sec_mipi_dsim_connector_get_modes+0x1c/0x34
[    3.262057]  drm_helper_probe_single_connector_modes+0x1ac/0x790
[    3.262065]  drm_mode_getconnector+0x2ac/0x570
[    3.262071]  drm_ioctl_kernel+0xc4/0x114
[    3.262077]  drm_ioctl+0x214/0x44c
[    3.262081]  __arm64_sys_ioctl+0xa8/0xf0
[    3.262087]  invoke_syscall+0x48/0x114
[    3.262093]  el0_svc_common.constprop.0+0x44/0xfc
[    3.262099]  do_el0_svc+0x28/0x90
[    3.262104]  el0_svc+0x28/0x80
[    3.262109]  el0t_64_sync_handler+0xa4/0x130
[    3.262115]  el0t_64_sync+0x1a0/0x1a4
[    3.262120] ---[ end trace d008dc3dcf118dff ]---
```
Some panels drivers have already been updated to implement the callback, so it makes sense to add support for this functionality here, which this patch does.