### PR TITLE
drivers: usb: lan78xx: add support to control LED mode register

### DIFF
--- a/drivers/net/usb/lan78xx.h
+++ b/drivers/net/usb/lan78xx.h
@@ -604,6 +604,9 @@
 #define MII_DATA			(0x124)
 #define MII_DATA_MASK_			(0x0000FFFF)
 
+#define MII_ACC_PHY_ADDR		(1)
+#define MII_IDX_LED_MODE_REG		(29)
+
 #define MAC_RGMII_ID			(0x128)
 #define MAC_RGMII_ID_TXC_DELAY_EN_	(0x00000002)
 #define MAC_RGMII_ID_RXC_DELAY_EN_	(0x00000001)


### PR DESCRIPTION
I am not really sure if this is the right place to suggest this contribution, but I don't know where else to do it.

Currently, the `lan78xx` driver is checking if `"microchip,led-modes"` property was set in the devicetree, then it only enables the LEDs by writing to the `HW_CFG` register. This however is not enough, as the property, when set, contains the value of each defined LED, and so it's necessary to read these values and write to the PHY LED Mode register accordingly. 

Following the documentation (Documentation/devicetree/bindings/net/microchip,lan78xx.txt):

```
Optional properties of the embedded PHY:
- microchip,led-modes: a 0..4 element vector, with each element configuring
  the operating mode of an LED. Omitted LEDs are turned off. Allowed values
  are defined in "include/dt-bindings/net/microchip-lan78xx.h".
```
