### PR TITLE
ASoC: fsl_esai: restore DAI format constants

### DIFF
--- a/sound/soc/fsl/fsl_esai.c
+++ b/sound/soc/fsl/fsl_esai.c
@@ -418,17 +418,17 @@ static int fsl_esai_set_dai_fmt(struct snd_soc_dai *dai, unsigned int fmt)
 	if (esai_priv->consumer_mode[0] == esai_priv->consumer_mode[1]) {
 		/* DAI clock master masks */
 		switch (fmt & SND_SOC_DAIFMT_MASTER_MASK) {
-		case SND_SOC_DAIFMT_CBM_CFM:
+		case SND_SOC_DAIFMT_BC_FC:
 			esai_priv->consumer_mode[0] = true;
 			esai_priv->consumer_mode[1] = true;
 			break;
-		case SND_SOC_DAIFMT_CBS_CFM:
+		case SND_SOC_DAIFMT_BP_FC:
 			xccr |= ESAI_xCCR_xCKD;
 			break;
-		case SND_SOC_DAIFMT_CBM_CFS:
+		case SND_SOC_DAIFMT_BC_FP:
 			xccr |= ESAI_xCCR_xFSD;
 			break;
-		case SND_SOC_DAIFMT_CBS_CFS:
+		case SND_SOC_DAIFMT_BP_FP:
 			xccr |= ESAI_xCCR_xFSD | ESAI_xCCR_xCKD;
 			esai_priv->consumer_mode[0] = false;
 			esai_priv->consumer_mode[1] = false;


### PR DESCRIPTION
The patch "MLK-19750-1: ASoC: fsl_esai: enhance async mode (part 1)", reverted the constants to their old naming and replaced with and used the wrong values: https://github.com/nxp-imx/linux-imx/blob/lf-6.1.y/include/sound/soc-dai.h#L127-L131

This results in the error:
  root@imx8qm-var-som:~# aplay /usr/share/sounds/alsa/Front_Center.wav
  [   21.241657] fsl-esai-dai 59010000.esai: failed to derive required SCKT rate
  [   21.248673] fsl-esai-dai 59010000.esai: ASoC: error at snd_soc_dai_hw_params on 59010000.esai: -22
  [   21.257795]  HiFi: ASoC: error at __soc_pcm_hw_params on HiFi: -22
  ALSA lib /usr/src/debug/alsa-lib/1.2.8-r0/src/pcm/pcm_direct.c:1336:(snd1_pcm_direct_initialize_slave) unable to install hw params
  ALSA lib /usr/src/debug/alsa-lib/1.2.8-r0/src/pcm/pcm_dmix.c:1011:(snd_pcm_dmix_open) unable to initialize slave
  aplay: main:831: audio open error: Invalid argument

This patch restores the original constants.

fixes: https://github.com/nxp-imx/linux-imx/commit/8734e7f599fa186b9ef0223b068a71f822bf7e69