### PR TITLE
fbdev: mxc_hdmi: hotplug: lock fb_info before modification

### DIFF
--- a/drivers/video/fbdev/mxc/mxc_hdmi.c
+++ b/drivers/video/fbdev/mxc/mxc_hdmi.c
@@ -1974,7 +1974,9 @@ static void mxc_hdmi_cable_connected(struct mxc_hdmi *hdmi)
 	}
 
 	/* Setting video mode */
+	lock_fb_info(hdmi->fbi);
 	mxc_hdmi_set_mode(hdmi);
+	unlock_fb_info(hdmi->fbi);
 
 	dev_dbg(&hdmi->pdev->dev, "%s exit\n", __func__);
 }


### PR DESCRIPTION
When an HDMI hotplug interrupt occurs, it schedules hotplug_worker(), which indirectly makes one or more calls to fb_videomode_to_var() that modify the fb_info struct associated with the HDMI connection. These can occur concurrently with the handling of an FBIOPUT_VSCREENINFO ioctl which also reads, modifies, and writes the same fields of fb_info, leading to race conditions.

This patch holds the fb_info lock in mxc_hdmi_cable_connected() while calling mxc_hdmi_set_mode(), eliminating those race conditions.

All of the hogplug handler's calls to fb_videomode_to_var() happen either directly or indirectly from mxc_hdmi_set_mode(), which is called from only one place, in mxc_hdmi_cable_connected(). That seems like the most convenient, least invasive, easiest to get right place to take and release the fb_info lock.