### PR TITLE
rtc: allow rtc_read_alarm without read_alarm callback

### DIFF
--- a/drivers/rtc/interface.c
+++ b/drivers/rtc/interface.c
@@ -392,7 +392,7 @@ int rtc_read_alarm(struct rtc_device *rtc, struct rtc_wkalrm *alarm)
 		return err;
 	if (!rtc->ops) {
 		err = -ENODEV;
-	} else if (!test_bit(RTC_FEATURE_ALARM, rtc->features) || !rtc->ops->read_alarm) {
+	} else if (!test_bit(RTC_FEATURE_ALARM, rtc->features)) {
 		err = -EINVAL;
 	} else {
 		memset(alarm, 0, sizeof(struct rtc_wkalrm));


### PR DESCRIPTION
it is needed to fix RTC wakealarm feature: adb shell "echo +20 > /sys/class/rtc/rtc0/wakealarm" on kernel 5.15

.read_alarm is not necessary to read the current alarm because it is recorded in the aie_timer and so rtc_read_alarm() will never call rtc_read_alarm_internal() which is the only function calling the callback.

Port of: 1e276e8acb8e24bce493603d19a699f76a1583fa