### PR TITLE
media: imx8-isi-cap: workaround of v4l2_subdev_format bad initialization

### DIFF
--- a/drivers/staging/media/imx/imx8-isi-cap.c
+++ b/drivers/staging/media/imx/imx8-isi-cap.c
@@ -961,6 +961,7 @@ static int mxc_isi_source_fmt_init(struct mxc_isi_cap_dev *isi_cap)
 	src_fmt.format.code = MEDIA_BUS_FMT_UYVY8_1X16;
 	src_fmt.format.width = dst_f->width;
 	src_fmt.format.height = dst_f->height;
+	src_fmt.stream = 0;
 	ret = v4l2_subdev_call(src_sd, pad, set_fmt, NULL, &src_fmt);
 	if (ret < 0 && ret != -ENOIOCTLCMD) {
 		v4l2_err(&isi_cap->sd, "set remote fmt fail!\n");


### PR DESCRIPTION
struct v4l2_subdev_format change from kernel 6.1.22 with a new stream field. This is not initialized into the imx8-isi-cap nxp driver and once you try to stream something check_state() of drivers/media/v4l2-core/v4l2-subdev.c return -EINVAL into the following statement:

if (stream != 0)
	return -EINVAL;

Let's initialize also this missing field into mxc_isi_source_fmt_init() to avoid the following error that prevent user to stream on ISI path:

mxc_isi.0: set remote fmt fail!