### PR TITLE
use print_hex_dump_debug() in imx_rpmsg_tty.c

### DIFF
--- a/drivers/rpmsg/imx_rpmsg_tty.c
+++ b/drivers/rpmsg/imx_rpmsg_tty.c
@@ -41,7 +41,7 @@ static int rpmsg_tty_cb(struct rpmsg_device *rpdev, void *data, int len,
 
 	dev_dbg(&rpdev->dev, "msg(<- src 0x%x) len %d\n", src, len);
 
-	print_hex_dump(KERN_DEBUG, __func__, DUMP_PREFIX_NONE, 16, 1,
+	print_hex_dump_debug(__func__, DUMP_PREFIX_NONE, 16, 1,
 			data, len,  true);
 
 	spin_lock_bh(&cport->rx_lock);


### PR DESCRIPTION
print_hex_dump_debug() uses print_hex_dump(KERN_DEBUG) if CONFIG_DYNAMIC_DEBUG is not set, but is uses Dynamic Debug if CONFIG_DYNAMIC_DEBUG is set.

Without this change, print_hex_dump(KERN_DEBUG) is used even if CONFIG_DYNAMIC_DEBUG is set, and so the end user cannot benefit from Dynamic Debug even it's enabled.

And all the messages sen to to rpmsg are logged into the journal without an easy way to disable this (the only way is to change the logging level for the whole kernel !!!!). Even when Dynamic Debu is enabled and available.

See support case 00636789