### PR TITLE
i2c-imx: Driver fixes

### DIFF
--- a/drivers/i2c/busses/i2c-imx.c
+++ b/drivers/i2c/busses/i2c-imx.c
@@ -722,10 +722,6 @@ static int i2c_imx_start(struct imx_i2c_struct *i2c_imx, bool atomic)
 	unsigned int temp = 0;
 	int result;
 
-	result = i2c_imx_set_clk(i2c_imx, clk_get_rate(i2c_imx->clk));
-	if (result)
-		return result;
-
 	imx_i2c_write_reg(i2c_imx->ifdr, i2c_imx, IMX_I2C_IFDR);
 	/* Enable I2C controller */
 	imx_i2c_write_reg(i2c_imx->hwdata->i2sr_clr_opcode, i2c_imx, IMX_I2C_I2SR);

--- a/drivers/i2c/busses/i2c-imx.c
+++ b/drivers/i2c/busses/i2c-imx.c
@@ -1860,7 +1860,7 @@ static int __maybe_unused i2c_imx_runtime_suspend(struct device *dev)
 {
 	struct imx_i2c_struct *i2c_imx = dev_get_drvdata(dev);
 
-	clk_disable_unprepare(i2c_imx->clk);
+	clk_disable(i2c_imx->clk);
 	pinctrl_pm_select_sleep_state(dev);
 
 	return 0;
@@ -1872,7 +1872,7 @@ static int __maybe_unused i2c_imx_runtime_resume(struct device *dev)
 	int ret;
 
 	pinctrl_pm_select_default_state(dev);
-	ret = clk_prepare_enable(i2c_imx->clk);
+	ret = clk_enable(i2c_imx->clk);
 	if (ret)
 		dev_err(dev, "can't enable I2C clock, ret=%d\n", ret);
 


### PR DESCRIPTION
We are noticing boot lock ups in the past 3 or 4 NXP kernel releases on some of our i.MX8M boards. The hang is always related to our i2c RTC. 

We figured out that the lock and mutex handing is done incorrect in the i2c-imx driver. 
The issues where already resolved upstream but it seems that due not properly solved rebase conflicts in the past they have been reintroduced again.

Please see the commit messages of the patches for more detailed information. We would appreciate if the issues are being resolved in future so that we do not have to apply the patches for every release.