### PR TITLE
Fixes: driver/gpu/drm/bridge adv7511_drv.c determines EDID read success when the DDC communication error

### DIFF
--- a/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
@@ -486,7 +486,7 @@ static int adv7511_irq_process(struct adv7511 *adv7511, bool process_hpd)
 	if (process_hpd && irq0 & ADV7511_INT0_HPD && adv7511->bridge.encoder)
 		schedule_work(&adv7511->hpd_work);
 
-	if (irq0 & ADV7511_INT0_EDID_READY || irq1 & ADV7511_INT1_DDC_ERROR) {
+	if (irq0 & ADV7511_INT0_EDID_READY) {
 		adv7511->edid_read = true;
 
 		if (adv7511->i2c_main->irq)


### PR DESCRIPTION
## Issue:
We found two issues happened following when the HPD event asserts.
・ADV7511/ADV7535 fails to read EDID(All 0x00) (Btw, it's okay until use)
・DRM tries to update new supported resolution list by using the wrong EDID(All 0x00)
→This sometimes causes unnecessary dynamic resolution changes to HDMI output from ADV7511/ADV7535.

## How to fix:
HDCP_ERROR_INT means HDCP/DDC controller error occurred, it does not mean EDID read success. However, the current implementation determines both ADV7511_INT0_EDID_READY and ADV7511_INT1_DDC_ERROR are EDID read successfully. ADV7511_INT1_DDC_ERROR should be handled as EDID read failed or EDID read timeout. The EDID read timeout sequence is already implemented in the adv7511_wait_for_edid(), so it is safe to ignore DDC_ERROR.

![image](https://github.com/user-attachments/assets/4c5997c3-68c3-4d54-82b7-df8ef488607a)
※screen captured register map is allowed to use by ADI

## Root cause:
adv7511_drv.c determines EDID read successfully when ADV7511/ADV7535 INT1 bit(HDCP_ERROR_INT) asserted.
(DRM debug log is following, added the ＠IRQ description)

## DRM debug log
DRM tries to specify new resolution by wrong EDID(All 0x00).
> [ 6937.533628] drm card1-HDMI-A-1: [drm:adv7511_irq_process] IRQ0:(80) @ADV7511_INT0_EDID_READY
[ 6937.533659] drm card1-HDMI-A-1: [drm:adv7511_irq_process] IRQ1:(00)
[ 6937.533982] drm card1-HDMI-A-1: [drm:adv7511_hpd_work] HDMI HPD event: connected
[ 6937.533992] [drm:drm_sysfs_hotplug_event] generating hotplug event
[ 6937.534058] imx-drm 32c00000.bus:display-subsystem: [drm:drm_client_dev_hotplug] fbdev: ret=0
[ 6937.535023] [drm:drm_ioctl] comm="weston" pid=658, dev=0xe201, auth=1, DRM_IOCTL_MODE_GETRESOURCES
[ 6937.535058] [drm:drm_ioctl] comm="weston" pid=658, dev=0xe201, auth=1, DRM_IOCTL_MODE_GETRESOURCES
[ 6937.535073] [drm:drm_ioctl] comm="weston" pid=658, dev=0xe201, auth=1, DRM_IOCTL_MODE_GETCONNECTOR
[ 6937.535087] [drm:drm_helper_probe_single_connector_modes] [CONNECTOR:35:HDMI-A-1]
[ 6937.538715] drm card1-HDMI-A-1: [drm:adv7511_irq_process] IRQ0:(00)
[ 6937.538742] drm card1-HDMI-A-1: [drm:adv7511_irq_process] IRQ1:(80) @ADV7511_INT1_DDC_ERROR
[ 6937.548077] imx-drm 32c00000.bus:display-subsystem: [drm:connector_bad_edid] HDMI-A-1: EDID is invalid:
[ 6937.548107]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.548111]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.548114]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.548117]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.548120]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.548123]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.548126]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.548129]  [00] ZERO 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 6937.551071] [drm:drm_mode_debug_printmodeline] Modeline "640x480": 60 25175 640 656 752 800 480 490 492 525 0x40 0xa
[ 6937.551097] [drm:drm_mode_prune_invalid] Not using 640x480 mode: NOCLOCK
[ 6937.551104] [drm:drm_mode_debug_printmodeline] Modeline "800x600": 56 36000 800 824 896 1024 600 601 603 625 0x40 0x5
[ 6937.551116] [drm:drm_mode_prune_invalid] Not using 800x600 mode: NOCLOCK
[ 6937.551122] [drm:drm_mode_debug_printmodeline] Modeline "800x600": 60 40000 800 840 968 1056 600 601 605 628 0x40 0x5
[ 6937.551136] [drm:drm_mode_prune_invalid] Not using 800x600 mode: BAD
[ 6937.551143] [drm:drm_mode_debug_printmodeline] Modeline "848x480": 60 33750 848 864 976 1088 480 486 494 517 0x40 0x5
[ 6937.551156] [drm:drm_mode_prune_invalid] Not using 848x480 mode: NOCLOCK
[ 6937.551164] [drm:drm_mode_debug_printmodeline] Modeline "1024x768": 60 65000 1024 1048 1184 1344 768 771 777 806 0x40 0xa
[ 6937.551178] [drm:drm_mode_prune_invalid] Not using 1024x768 mode: BAD
