### PR TITLE
Apply two missing stable patches to fix eMMC timeouts

### DIFF
--- a/drivers/mmc/core/block.c
+++ b/drivers/mmc/core/block.c
@@ -413,7 +413,7 @@ static struct mmc_blk_ioc_data *mmc_blk_ioctl_copy_from_user(
 	struct mmc_blk_ioc_data *idata;
 	int err;
 
-	idata = kmalloc(sizeof(*idata), GFP_KERNEL);
+	idata = kzalloc(sizeof(*idata), GFP_KERNEL);
 	if (!idata) {
 		err = -ENOMEM;
 		goto out;

--- a/drivers/mmc/core/block.c
+++ b/drivers/mmc/core/block.c
@@ -488,7 +488,7 @@ static int __mmc_blk_ioctl_cmd(struct mmc_card *card, struct mmc_blk_data *md,
 	if (idata->flags & MMC_BLK_IOC_DROP)
 		return 0;
 
-	if (idata->flags & MMC_BLK_IOC_SBC)
+	if (idata->flags & MMC_BLK_IOC_SBC && i > 0)
 		prev_idata = idatas[i - 1];
 
 	/*


### PR DESCRIPTION
The eMMC on imx93 systems will randomly stop responding to all requests when any program is running "mmc rpmb read-block".

It is extremely easy to reproduce, as follows:

```
    root@imx93:~# while :; do mmc rpmb read-block /dev/mmcblk0rpmb 0x1 256 - &>/dev/null; done &
    [1] 460
    root@imx93:~# find / -exec dd if={} of=/dev/null bs=1M \; &>/dev/null
    [  234.190235][ T2972] mmc0: Card stuck being busy! __mmc_poll_for_busy
    [  234.196958][ T2972] I/O error, dev mmcblk0, sector 292888 op 0x0:(READ) flags 0x3000 phys_seg 1 prio class 2
    [  234.209970][ T2972] I/O error, dev mmcblk0, sector 1809592 op 0x1:(WRITE) flags 0x9800 phys_seg 52 prio class 2
    [  234.220785][  T229] I/O error, dev mmcblk0, sector 292888 op 0x0:(READ) flags 0x3000 phys_seg 1 prio class 2
    [  234.221491][   T77] Aborting journal on device mmcblk0p2-8.
    [  234.239485][ T2975] EXT4-fs error (device mmcblk0p2): ext4_journal_check_start:84: comm dd: Detected aborted journal
    [  234.242671][   T40] I/O error, dev mmcblk0, sector 1806336 op 0x1:(WRITE) flags 0x29800 phys_seg 1 prio class 2
    [  234.260229][   T40] Buffer I/O error on dev mmcblk0p2, logical block 196608, lost sync page write
    [  234.269626][   T77] JBD2: I/O error when updating journal superblock for mmcblk0p2-8.
    [  234.278488][   T40] I/O error, dev mmcblk0, sector 233472 op 0x1:(WRITE) flags 0x23800 phys_seg 1 prio class 2
    [  234.288786][   T40] Buffer I/O error on dev mmcblk0p2, logical block 0, lost sync page write
    [  234.297432][ T2975] EXT4-fs (mmcblk0p2): I/O error while writing superblock
    [  234.304741][ T2975] EXT4-fs (mmcblk0p2): Remounting filesystem read-only
    [  234.500919][   T40] I/O error, dev mmcblk0, sector 289696 op 0x0:(READ) flags 0x3000 phys_seg 1 prio class 2
    [  234.511722][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #24: lblock 0: comm find: error -5 reading directory block
    [  234.534937][   T40] I/O error, dev mmcblk0, sector 290728 op 0x0:(READ) flags 0x3000 phys_seg 1 prio class 2
    [  234.544969][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #129: lblock 0: comm find: error -5 reading directory block
    [  234.567802][  T229] I/O error, dev mmcblk0, sector 290552 op 0x0:(READ) flags 0x3000 phys_seg 1 prio class 2
    [  234.577873][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #114: lblock 0: comm find: error -5 reading directory block
    [  234.593081][  T229] I/O error, dev mmcblk0, sector 290008 op 0x0:(READ) flags 0x3000 phys_seg 1 prio class 2
    [  234.603315][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #62: lblock 0: comm find: error -5 reading directory block
    [  234.619192][  T229] I/O error, dev mmcblk0, sector 294192 op 0x0:(READ) flags 0x3000 phys_seg 1 prio class 2
    [  234.629216][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #487: lblock 0: comm find: error -5 reading directory block
    [  234.650904][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #501: lblock 0: comm find: error -5 reading directory block
    [  234.714862][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #550: lblock 0: comm find: error -5 reading directory block
    [  234.735667][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #216: lblock 0: comm find: error -5 reading directory block
    [  234.755631][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #599: lblock 0: comm find: error -5 reading directory block
    [  234.772059][ T2564] EXT4-fs warning (device mmcblk0p2): htree_dirblock_to_tree:1082: inode #604: lblock 0: comm find: error -5 reading directory block
    [  238.742634][ T2564] EXT4-fs warning (device mmcblk0p5): htree_dirblock_to_tree:1082: inode #2: lblock 0: comm find: error -5 reading directory block
```

This happens because of a bug in a patch from upstream stable. It is fixed by later patches in stable, but because linux-imx is very far behind upstream stable, it is missing those fixes.

This is the buggy patch, from v6.6.15:

    https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.6.y&id=1653a8102868

These are the two patches which fix it, from v6.6.24:

    https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.6.y&id=35ee8529eee7
    https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.6.y&id=4466677dcabe

Please apply 35ee8529eee7 and 4466677dcabe as soon as possible. This PR contains those two patches.

Thanks,
Calvin