### PR TITLE
ARM64: boot: dts: fix i.MX91 pinfunc GPIO typos

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx91-11x11-evk.dts
+++ b/arch/arm64/boot/dts/freescale/imx91-11x11-evk.dts
@@ -692,7 +692,7 @@
 			MX91_PAD_ENET1_TD0__GPIO4_IO5                          0x31e
 			MX91_PAD_ENET1_TD1__GPIO4_IO4                          0x31e
 			MX91_PAD_ENET1_TD2__GPIO4_IO3				0x31e
-			MX91_PAD_ENET1_TD3__GPIO4_IO3				0x31e
+			MX91_PAD_ENET1_TD3__GPIO4_IO2				0x31e
 			MX91_PAD_ENET1_TXC__GPIO4_IO7                          0x31e
 			MX91_PAD_ENET1_TX_CTL__GPIO4_IO6                       0x31e
 		>;

--- a/arch/arm64/boot/dts/freescale/imx91-pinfunc.h
+++ b/arch/arm64/boot/dts/freescale/imx91-pinfunc.h
@@ -330,7 +330,7 @@
 #define MX91_PAD_ENET1_TD3__CAN2_TX                                              0x00A0 0x0250 0x0000 0x02 0x00
 #define MX91_PAD_ENET1_TD3__HSIOMIX_OTG_ID2                                      0x00A0 0x0250 0x0000 0x03 0x00
 #define MX91_PAD_ENET1_TD3__FLEXIO2_FLEXIO2                                      0x00A0 0x0250 0x0000 0x04 0x00
-#define MX91_PAD_ENET1_TD3__GPIO4_IO3                                            0x00A0 0x0250 0x0000 0x05 0x00
+#define MX91_PAD_ENET1_TD3__GPIO4_IO2                                            0x00A0 0x0250 0x0000 0x05 0x00
 #define MX91_PAD_ENET1_TD3__LPI2C2_SCL                                           0x00A0 0x0250 0x03E8 0x06 0x00
 
 #define MX91_PAD_ENET1_TD2__ENET_QOS_RGMII_TD2                                   0x00A4 0x0254 0x0000 0x00 0x00
@@ -680,7 +680,7 @@
 #define MX91_PAD_I2C2_SCL__LPUART2_DCB_B                                         0x0178 0x0328 0x0000 0x02 0x00
 #define MX91_PAD_I2C2_SCL__TPM2_CH2                                              0x0178 0x0328 0x0000 0x03 0x00
 #define MX91_PAD_I2C2_SCL__SAI1_RX_SYNC                                          0x0178 0x0328 0x0000 0x04 0x00
-#define MX91_PAD_I2C2_SCL__GPIO1_IO3                                             0x0178 0x0328 0x0000 0x05 0x00
+#define MX91_PAD_I2C2_SCL__GPIO1_IO2                                             0x0178 0x0328 0x0000 0x05 0x00
 #define MX91_PAD_I2C2_SCL__I3C1_PUR_B                                            0x0178 0x0328 0x0000 0x06 0x00
 
 #define MX91_PAD_I2C2_SDA__LPI2C2_SDA                                            0x017C 0x032C 0x03EC 0x00 0x01


### PR DESCRIPTION
Fix typos for I2C2_SCL and ENET1_TD3 GPIO iomuxes.