### PR TITLE
gpu-viv: Fix crash in gckGALDEVICE_Destroy()

### DIFF
--- a/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_device.c
+++ b/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_device.c
@@ -1589,9 +1589,10 @@ _DebugfsCleanup(IN gckGALDEVICE Device)
     }
 #else
     /* TODO. */
-    struct device *dev = (struct device *)Device->devices[0]->dev;
-
-    sysfs_remove_groups(&dev->kobj, Info_groups);
+    if (Device && Device->devices[0] != gcvNULL) {
+        struct device *dev = (struct device *)Device->devices[0]->dev;
+        sysfs_remove_groups(&dev->kobj, Info_groups);
+    }
 #endif
 }
 
@@ -2824,6 +2825,7 @@ gckGALDEVICE_Destroy(gckGALDEVICE gal_device)
 
             gcmkVERIFY_OK(gckDEVICE_Destroy(device->os, device));
 
+            gal_device->devices[devIndex] = gcvNULL;
             device = gcvNULL;
         }
 


### PR DESCRIPTION
**Description:**
Fix a kernel crash caused by a dangling pointer in gal_device->devices[devIndex].

The memory pointed to by gal_device->devices[devIndex] was freed via gcmkVERIFY_OK(gckDEVICE_Destroy(device->os, device)), but the pointer itself was not cleared, leaving a dangling reference.
Later, this stale pointer was dereferenced in _DebugfsCleanup(), leading to a kernel crash due to invalid memory access.
This patch addresses the issue by setting gal_device->devices[devIndex] = gcvNULL immediately after the device is destroyed, preventing any further use of freed memory.

**Crash Logs:**
- Unable to handle kernel paging request at virtual address ffff800081b06298

- Kernel paging request at ffff800081b06298 with no valid PTE.
  [ffff800081b06298] pgd=100000013ffff003, p4d=100000013ffff003,
  pud=100000013fffe003, pmd=100000010002a003, pte=0000000000000000

- Faulting instruction: ldr x20, [x0, #0x12a8]
  Code: aa1803e0 528166e2 97d3ba16 f940ee60 (f9494c14) [CRASH LOGS]
  1978: f9494c14  ldr x20, [x0, #4760] [DRIVER DISASSEMBLY]

- Base address (x0): ffff800081b05000
- Fault address: x0 + 0x12a8 = ffff800081b06298

**Fix:**
Set gal_device->devices[devIndex] = gcvNULL after gckDEVICE_Destroy() to nullify the dangling pointer and prevent use-after-free.