### PR TITLE
drivers: firmware: imx: fix dependency for IMX_SEC_ENCLAVE

### DIFF
--- a/drivers/firmware/imx/Kconfig
+++ b/drivers/firmware/imx/Kconfig
@@ -58,7 +58,7 @@ config IMX_SCMI_MISC_DRV
 
 config IMX_SEC_ENCLAVE
 	tristate "i.MX Embedded Secure Enclave - EdgeLock Enclave Firmware driver."
-	depends on IMX_MBOX && ARCH_MXC && ARM64
+	depends on NVMEM_IMX_OCOTP_SCU && IMX_MBOX && ARCH_MXC && ARM64
 	select FW_LOADER
 	default m if ARCH_MXC
 


### PR DESCRIPTION
IMX_SEC_ENCLAVE access the 'nvmem', thus on i.MX 8DXL/QXP/QM the following is required: NVMEM_IMX_OCOTP_SCU.
Add it to the depends.

With a missing NVMEM_IMX_OCOTP_SCU or with IMX_SEC_ENCLAVE=y and NVMEM_IMX_OCOTP_SCU=m we get repeated kernel messages as follows:

kern  :err   : [    1.911106] fsl-se secure-envlave-1: Fail to read FIPS fuse
kern  :err   : [    1.921674] fsl-se secure-envlave-1: Failed to fetch SoC Info.
kern  :err   : [    1.927537] fsl-se secure-envlave-1: failed[-EPROBE_DEFER] to fetch SoC Info
kern  :err   : [    1.938511] fsl-se secure-envlave-1: Fail to read FIPS fuse
kern  :err   : [    1.944164] fsl-se secure-envlave-1: Failed to fetch SoC Info.
kern  :info  : [    1.947717] mmc1: SDHCI controller on 5b020000.mmc [5b020000.mmc] using ADMA
kern  :err   : [    1.950016] fsl-se secure-envlave-1: failed[-EPROBE_DEFER] to fetch SoC Info
kern  :warn  : [    1.964431] ------------[ cut here ]------------
kern  :warn  : [    1.969110] kobject: '' ((____ptrval____)): is not initialized, yet kobject_put() is being called.
kern  :warn  : [    1.978159] WARNING: CPU: 0 PID: 11 at /lib/kobject.c:734 kobject_put+0xf0/0x218
kern  :warn  : [    1.985591] Modules linked in:
kern  :warn  : [    1.988664] CPU: 0 PID: 11 Comm: kworker/u8:0 Not tainted 6.6.101-7.4.0-devel #1
kern  :warn  : [    1.996086] Hardware name: Toradex Colibri iMX8QXP on Colibri Evaluation Board V3 (DT)
kern  :warn  : [    2.004020] Workqueue: events_unbound deferred_probe_work_func
kern  :warn  : [    2.009878] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
kern  :warn  : [    2.016853] pc : kobject_put+0xf0/0x218
kern  :warn  : [    2.020699] lr : kobject_put+0xf0/0x218
kern  :warn  : [    2.024548] sp : ffffffc08008bac0
kern  :warn  : [    2.027877] x29: ffffffc08008bac0 x28: 0000000000000000 x27: 0000000000000000
kern  :warn  : [    2.035045] x26: ffffff8000410028 x25: ffffff80004297c0 x24: ffffff800040fa0d
kern  :warn  : [    2.042213] x23: 0000000000000008 x22: ffffffc08008bb38 x21: ffffff8000633c10
kern  :warn  : [    2.049371] x20: ffffff8000633c10 x19: ffffff80022a2300 x18: 0000000000000006
kern  :warn  : [    2.056538] x17: 5f7463656a626f6b x16: 20746579202c6465 x15: 0720072007200720
kern  :warn  : [    2.063705] x14: 0720072007200720 x13: ffffffd8ee42ad10 x12: 00000000000002b5
kern  :warn  : [    2.070873] x11: 00000000000000e7 x10: ffffffd8ee482d10 x9 : ffffffd8ee42ad10
kern  :warn  : [    2.078040] x8 : 00000000ffffefff x7 : ffffffd8ee482d10 x6 : 80000000fffff000
kern  :warn  : [    2.085207] x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
kern  :warn  : [    2.092374] x2 : 0000000000000000 x1 : 0000000000000000 x0 : ffffff80004a8e00
kern  :warn  : [    2.099544] Call trace:
kern  :warn  : [    2.101997]  kobject_put+0xf0/0x218
kern  :warn  : [    2.105500]  se_if_probe_cleanup+0xf8/0x134
kern  :warn  : [    2.109703]  devm_action_release+0x14/0x20
kern  :warn  : [    2.113812]  devres_release_all+0xa8/0x110
kern  :warn  : [    2.117922]  device_unbind_cleanup+0x18/0x68
kern  :warn  : [    2.122214]  really_probe+0x120/0x3c4
kern  :warn  : [    2.125888]  __driver_probe_device+0x7c/0x16c
kern  :warn  : [    2.130260]  driver_probe_device+0x3c/0x110
kern  :warn  : [    2.134463]  __device_attach_driver+0xbc/0x158
kern  :warn  : [    2.138928]  bus_for_each_drv+0x88/0xe8
kern  :warn  : [    2.142776]  __device_attach+0xa0/0x1b4
kern  :warn  : [    2.146625]  device_initial_probe+0x14/0x20
kern  :warn  : [    2.150821]  bus_probe_device+0xa8/0xac
kern  :warn  : [    2.154669]  deferred_probe_work_func+0x94/0xe4
kern  :warn  : [    2.159214]  process_one_work+0x144/0x29c
kern  :warn  : [    2.163245]  worker_thread+0x31c/0x434
kern  :warn  : [    2.167006]  kthread+0x110/0x114
kern  :warn  : [    2.170246]  ret_from_fork+0x10/0x20
kern  :warn  : [    2.173837] ---[ end trace 0000000000000000 ]---

Fixes: 4faa6aeb8bc3 ("LF-13910-8: drivers: firmware: imx: add support for i.MX8DXL/QXP/QM")