### PR TITLE
drivers: firmware: imx: fix dependency for IMX_SEC_ENCLAVE and use-after-free

### DIFF
--- a/drivers/firmware/imx/Kconfig
+++ b/drivers/firmware/imx/Kconfig
@@ -58,7 +58,7 @@ config IMX_SCMI_MISC_DRV
 
 config IMX_SEC_ENCLAVE
 	tristate "i.MX Embedded Secure Enclave - EdgeLock Enclave Firmware driver."
-	depends on IMX_MBOX && ARCH_MXC && ARM64
+	depends on NVMEM_IMX_OCOTP_SCU && IMX_MBOX && ARCH_MXC && ARM64
 	select FW_LOADER
 	default m if ARCH_MXC
 

--- a/drivers/firmware/imx/se_ctrl.c
+++ b/drivers/firmware/imx/se_ctrl.c
@@ -2076,11 +2076,6 @@ static void se_if_probe_cleanup(void *plat_dev)
 	 * un-set bit.
 	 */
 	of_reserved_mem_device_release(dev);
-
-	/* Free Kobj created for logging */
-	if (se_kobj)
-		kobject_put(se_kobj);
-
 }
 
 static int get_se_fw_img_nm_idx(const struct se_fw_img_name *se_fw_img_nm)
@@ -2280,6 +2275,8 @@ static int se_if_probe(struct platform_device *pdev)
 		ret = se_sysfs_log();
 		if (ret)
 			pr_warn("Warn: Creating sysfs entry for se_log and  se_rcv_msg_timeout: %d\n", ret);
+	} else {
+		kobject_get(se_kobj);
 	}
 
 	dev_info(dev, "i.MX secure-enclave: %s%d interface to firmware, configured.\n",
@@ -2296,6 +2293,10 @@ exit:
 static void se_if_remove(struct platform_device *pdev)
 {
 	se_if_probe_cleanup(pdev);
+
+	/* Free Kobj created for logging */
+	if (se_kobj)
+		kobject_put(se_kobj);
 }
 
 static int se_suspend(struct device *dev)


### PR DESCRIPTION
Hi, previously @MaxKrummenacher opened https://github.com/nxp-imx/linux-imx/pull/31

We since noticed that there are still issues with this driver, and now have a second commit to fix these. Doing this I noticed that we still need Max's earlier fix, but for functional reasons. The attached stack trace in the original commit message from Max is seemingly not caused by the issue it fixes but by another one.

I have therefore attached both commits but edited Max's commit message.

Please let me know if additional info aside from the commit messages is needed, and thanks for taking the time to investigate this.

@dbaluta 

