### PR TITLE
drm/of: prevent compiler warning

### DIFF
--- a/include/drm/drm_of.h
+++ b/include/drm/drm_of.h
@@ -85,7 +85,7 @@ drm_of_component_match_add(struct device *master,
 {
 }
 
-static int drm_of_component_probe_with_match(struct device *dev,
+static inline int drm_of_component_probe_with_match(struct device *dev,
 			   struct component_match *match,
 			   int (*compare_of)(struct device *, void *),
 			   const struct component_master_ops *m_ops)


### PR DESCRIPTION
When building for x86-64 the compiler complains that drm_of_component_probe_with_match is defined but not used and the build fails as all warnings are treated as errors in that case.

Fix it by adding inline the same way as all other 'empty' functions are defined.

Reproduce:
- Setup the environment on a x86-64 host to build natively
- make defconfig
- make -j$(nproc)