### PR TITLE
media: csi2-sam: Fix the gasket debug register information

### DIFF
--- a/drivers/staging/media/imx/imx8-mipi-csi2-sam.c
+++ b/drivers/staging/media/imx/imx8-mipi-csi2-sam.c
@@ -566,9 +566,9 @@ static void dump_gasket_regs(struct csi_state *state, const char *label)
 		u32 offset;
 		const char * const name;
 	} registers[] = {
-		{ 0x60, "GPR_GASKET_0_CTRL" },
-		{ 0x64, "GPR_GASKET_0_HSIZE" },
-		{ 0x68, "GPR_GASKET_0_VSIZE" },
+		{ 0x0, "GPR_GASKET_n_CTRL" },
+		{ 0x4, "GPR_GASKET_n_HSIZE" },
+		{ 0x8, "GPR_GASKET_n_VSIZE" },
 	};
 	u32 i, cfg;
 


### PR DESCRIPTION
The regmap_read uses the base address of the gasket dts node. Those addresses start at the control registers of its respective gasket, not at the media block address.

Example from imx8mp.dtsi:

mediamix_gasket0: gasket@32ec0060 {
	compatible = "fsl,imx8mp-iomuxc-gpr", "syscon";
	reg = <0x32ec0060 0x28>;
};

mediamix_gasket1: gasket@32ec0090 {
	compatible = "fsl,imx8mp-iomuxc-gpr", "syscon";
	reg = <0x32ec0090 0x28>;
};