### PR TITLE
clk: imx: fix NULL pointer deref in imx_unregister_hw_clocks() error path

### DIFF
--- a/drivers/clk/imx/clk.c
+++ b/drivers/clk/imx/clk.c
@@ -25,8 +25,10 @@ void imx_unregister_hw_clocks(struct clk_hw *hws[], unsigned int count)
 {
 	unsigned int i;
 
-	for (i = 0; i < count; i++)
-		clk_hw_unregister(hws[i]);
+	for (i = 0; i < count; i++) {
+		if (!IS_ERR_OR_NULL(hws[i]))
+			clk_hw_unregister(hws[i]);
+	}
 }
 EXPORT_SYMBOL_GPL(imx_unregister_hw_clocks);
 


### PR DESCRIPTION
## Summary

`imx_unregister_hw_clocks()` unconditionally calls `clk_hw_unregister()` for
every entry in the `hws[]` array up to `count`, including entries that were
never populated because the calling probe function returned early on error
before filling the whole array. Those unfilled entries are still NULL, so
`clk_hw_unregister(NULL)` dereferences a NULL pointer and crashes.

## How it was found

Reproduced on **FRDM-IMX91** (i.MX91, standalone U-Boot/kernel build,
`imx91_11x11_frdm_defconfig` + `imx91-11x11-frdm.dtb`) when
`imx93_clocks_probe()` (shared clock driver for i.MX91/i.MX93) jumps to the
`unregister_hws` error path after `devm_of_iomap()` fails on the
`"fsl,imx93-anatop"` node:

```
WARNING: CPU: 0 PID: 1 at drivers/clk/imx/clk-imx93.c:339 imx93_clocks_probe+0x5bc/0x5d8
...
Unable to handle kernel NULL pointer dereference ... clk_hw_unregister+0xc/0x20
Kernel panic - not syncing: Attempted to kill init!
```

`imx_unregister_hw_clocks(clks, IMX93_CLK_END)` walks past the ~10 clocks
actually registered before the failure and hits NULL entries, turning a
recoverable probe failure into a full kernel panic.

## Fix

Skip entries that are NULL or an error pointer before unregistering.

## Test plan

- [x] Booted on FRDM-IMX91 hardware: before the fix, `imx93_clocks_probe()`
      failure escalates to a kernel panic (`Attempted to kill init!`).
      After the fix, the probe fails gracefully (`error -22`), boot
      continues normally, and the kernel reaches the expected
      `VFS: Unable to mount root fs` stop point (no rootfs attached in this
      test setup).

## Update: root cause of the underlying `imx93_clocks_probe()` failure identified

An earlier version of this description speculated the `devm_of_iomap()`
failure on the anatop node was related to TRDC access configuration in ATF.
**That hypothesis has since been disproven by elimination testing** and is
retracted so it doesn't mislead anyone investigating further:

| Components (SPL / BL31+OP-TEE / kernel) | Result |
|---|---|
| standalone-built / standalone-built / `lf-6.18.y` | fails |
| standalone-built / **extracted from NXP's official `imx-boot-imx91frdm-sd.bin-flash_singleboot`** / `lf-6.18.y` | fails identically |
| **extracted from NXP's official image** / extracted from NXP's official image / `lf-6.18.y` | fails identically |
| extracted from NXP's official image / extracted from NXP's official image / **`lf-6.12.y`** | **no failure, boots to login** |

Swapping SPL and then BL31+OP-TEE for NXP's own known-good binaries (from
their validated FRDM release) did not change the outcome at all — same
crash, same offsets. The only change that fixed it was switching the kernel
branch from `lf-6.18.y` to `lf-6.12.y`. Since `imx93_clocks_probe()` runs
entirely in kernel space, well after firmware hand-off, this rules out
SPL/ATF/OP-TEE/TRDC and points to a `lf-6.18.y`-specific regression in the
`imx93-ccm` driver or its interaction with the FRDM-IMX91 DT on that branch.
This PR's NULL-check fix remains correct and worth keeping regardless (any
early probe failure elsewhere would hit the same crash), but it does not
address that separate `lf-6.18.y` regression, which needs its own
investigation/issue.